### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ async-trait = "0.1.36"
 clap = "2.33.1"
 native-tls = { version = "0.2", optional = true }
 regex = "1.3.7"
-rusoto_core = { version = "0.43.0", optional = true }
-rusoto_ec2 = { version = "0.43.0", optional = true }
-rusoto_ssm = { version = "0.43.0", optional = true }
-surf = "1.0.3"
-tokio = { version = "0.2.21", features = ["macros"] }
+rusoto_core = { version = "0.47.0", optional = true }
+rusoto_ec2 = { version = "0.47.0", optional = true }
+rusoto_ssm = { version = "0.47.0", optional = true }
+surf = "2.2.0"
+tokio = { version = ">= 1", features = ["full"] }
 
 [dev-dependencies]
-mockito = "0.25.1"
-rusoto_mock = "0.43.0"
+mockito = "0.30.0"
+rusoto_mock = "0.47.0"
 
 [features]
 default = ["aws"]


### PR DESCRIPTION
This updates a few of germinate's dependencies to let it work with newer Tokio runtimes (otherwise it'll simply refuse to do its job because it cannot find a valid 0.2.x runtime for Tokio). I've run the tests that were available and also integrated it into a real-life project (using EC2 metadata _and_ SSM) without any noticeable difference.